### PR TITLE
feat: 리턴 타입 capacityType 추가 (#14)

### DIFF
--- a/src/main/java/com/onna/onnaback/domain/apply/adapter/in/web/response/ApplyDto.java
+++ b/src/main/java/com/onna/onnaback/domain/apply/adapter/in/web/response/ApplyDto.java
@@ -3,6 +3,7 @@ package com.onna.onnaback.domain.apply.adapter.in.web.response;
 import java.time.LocalDateTime;
 
 import com.onna.onnaback.domain.apply.domain.AcceptStatus;
+import com.onna.onnaback.domain.spark.domain.CapacityType;
 import com.onna.onnaback.domain.spark.domain.DurationHour;
 
 import lombok.AllArgsConstructor;
@@ -23,6 +24,8 @@ public class ApplyDto {
     private Long memberCount;
 
     private Long capacity;
+
+    private CapacityType capacityType;
 
     private Long price;
 

--- a/src/main/java/com/onna/onnaback/domain/apply/adapter/out/persistence/ApplyPersistenceAdapter.java
+++ b/src/main/java/com/onna/onnaback/domain/apply/adapter/out/persistence/ApplyPersistenceAdapter.java
@@ -55,6 +55,7 @@ public class ApplyPersistenceAdapter implements SaveApplyPort, LoadApplyPort {
                                        memberSparkMapping.getApplySpark().getDurationHour(),
                                        memberSparkMapping.getApplySpark().getMemberCount(),
                                        memberSparkMapping.getApplySpark().getCapacity(),
+                                       memberSparkMapping.getApplySpark().getCapacityType(),
                                        memberSparkMapping.getApplySpark().getPrice(),
                                        memberSparkMapping.getApplySpark().getImg(),
                                        memberSparkMapping.getApplySpark().getTitle(),

--- a/src/main/java/com/onna/onnaback/domain/spark/adapter/in/web/response/SparkListDto.java
+++ b/src/main/java/com/onna/onnaback/domain/spark/adapter/in/web/response/SparkListDto.java
@@ -2,6 +2,7 @@ package com.onna.onnaback.domain.spark.adapter.in.web.response;
 
 import java.time.LocalDateTime;
 
+import com.onna.onnaback.domain.spark.domain.CapacityType;
 import com.onna.onnaback.domain.spark.domain.DurationHour;
 import com.onna.onnaback.domain.spark.domain.RecruitType;
 import com.onna.onnaback.domain.spark.domain.SparkType;
@@ -30,6 +31,8 @@ public class SparkListDto {
     DurationHour durationHour;
 
     Long capacity;
+
+    CapacityType capacityType;
 
     Long memberCount;
 

--- a/src/main/java/com/onna/onnaback/domain/spark/adapter/in/web/response/SparkResponse.java
+++ b/src/main/java/com/onna/onnaback/domain/spark/adapter/in/web/response/SparkResponse.java
@@ -3,6 +3,7 @@ package com.onna.onnaback.domain.spark.adapter.in.web.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.onna.onnaback.domain.spark.domain.CapacityType;
 import com.onna.onnaback.domain.spark.domain.DurationHour;
 import com.onna.onnaback.domain.spark.domain.RecruitType;
 import com.onna.onnaback.domain.spark.domain.SparkType;
@@ -31,6 +32,8 @@ public class SparkResponse {
     DurationHour durationHour;
 
     Long capacity;
+
+    CapacityType capacityType;
 
     Long memberCount;
 

--- a/src/main/java/com/onna/onnaback/domain/spark/adapter/out/persistence/SparkPersistenceAdapter.java
+++ b/src/main/java/com/onna/onnaback/domain/spark/adapter/out/persistence/SparkPersistenceAdapter.java
@@ -124,6 +124,7 @@ public class SparkPersistenceAdapter implements LoadSparkPort, SaveSparkPort {
                         spark.getSparkDate(),
                         spark.getDurationHour(),
                         spark.getCapacity(),
+                        spark.getCapacityType(),
                         spark.getMemberCount(),
                         spark.getRecruitType(),
                         spark.getPlace().getImg(),
@@ -191,6 +192,7 @@ public class SparkPersistenceAdapter implements LoadSparkPort, SaveSparkPort {
                             .price(spark.getPrice())
                             .durationHour(spark.getDurationHour())
                             .capacity(spark.getCapacity())
+                            .capacityType(spark.getCapacityType())
                             .hostName(spark.getHost().getName())
                             .hostImg(spark.getHost().getProfileImg())
                             .hostDetail(spark.getHostDetail())


### PR DESCRIPTION
## ISSUE ✅ :
- 아래 api에 capacityType도 리턴

```
/api/apply/list/{memberId}
/api/spark/{sparkId}
/api/spark/list
/api/spark/place/{placeId}
```